### PR TITLE
add option to keep wiki style links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,7 @@ pub struct Exporter<'a> {
     vault_contents: Option<Vec<PathBuf>>,
     walk_options: WalkOptions<'a>,
     process_embeds_recursively: bool,
+    keep_wiki_links: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -230,6 +231,7 @@ impl<'a> Exporter<'a> {
             walk_options: WalkOptions::default(),
             process_embeds_recursively: true,
             vault_contents: None,
+            keep_wiki_links: false,
         }
     }
 
@@ -255,6 +257,11 @@ impl<'a> Exporter<'a> {
     /// original note, instead of embedding it again a link to the note is inserted instead.
     pub fn process_embeds_recursively(&mut self, recursive: bool) -> &mut Exporter<'a> {
         self.process_embeds_recursively = recursive;
+        self
+    }
+
+    pub fn keep_wiki_links(&mut self, keep:bool) -> &mut Exporter<'a> {
+        self.keep_wiki_links = keep;
         self
     }
 
@@ -567,11 +574,22 @@ impl<'a> Exporter<'a> {
             CowStr::from(""),
         );
 
-        vec![
-            Event::Start(link_tag.clone()),
-            Event::Text(CowStr::from(reference.display())),
-            Event::End(link_tag.clone()),
-        ]
+        eprintln!("reference display: {}, file: {}", reference.display(), reference.file);
+
+        if !self.keep_wiki_links {
+            vec![
+                Event::Start(link_tag.clone()),
+                Event::Text(CowStr::from(reference.display())),
+                Event::End(link_tag.clone()),
+            ]
+        }
+        else {
+            vec![
+                Event::Text(CowStr::from("[[")),
+                Event::Text(CowStr::from(reference.display())),
+                Event::Text(CowStr::from("]]")),
+            ]
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,10 @@ struct Opts {
 
     #[options(no_short, help = "Don't process embeds recursively", default = "false")]
     no_recursive_embeds: bool,
+
+    #[options(no_short, help = "Keep wiki-links", default = "false")]
+    keep_wiki_links: bool,
+
 }
 
 fn frontmatter_strategy_from_str(input: &str) -> Result<FrontmatterStrategy> {
@@ -63,6 +67,7 @@ fn main() -> Result<()> {
     exporter.frontmatter_strategy(args.frontmatter_strategy);
     exporter.process_embeds_recursively(!args.no_recursive_embeds);
     exporter.walk_options(walk_options);
+    exporter.keep_wiki_links(args.keep_wiki_links);
 
     if let Err(err) = exporter.run() {
         match err {

--- a/tests/export_test.rs
+++ b/tests/export_test.rs
@@ -290,6 +290,25 @@ fn test_no_recursive_embeds() {
     );
 }
 
+
+#[test]
+fn test_keep_wiki_links() {
+    let tmp_dir = TempDir::new().expect("failed to make tempdir");
+
+    let mut exporter = Exporter::new(
+        PathBuf::from("tests/testdata/input/keep-wiki-links/"),
+        tmp_dir.path().to_path_buf(),
+    );
+    exporter.keep_wiki_links(true);
+    exporter.run().expect("exporter returned error");
+
+    assert_eq!(
+        read_to_string("tests/testdata/expected/keep-wiki-links/Note.md").unwrap(),
+        read_to_string(tmp_dir.path().clone().join(PathBuf::from("Note.md"))).unwrap(),
+    );
+}
+
+
 #[test]
 fn test_non_ascii_filenames() {
     let tmp_dir = TempDir::new().expect("failed to make tempdir");

--- a/tests/testdata/expected/keep-wiki-links/Note.md
+++ b/tests/testdata/expected/keep-wiki-links/Note.md
@@ -1,0 +1,7 @@
+Even though we're exporting from Obsidian, I *Want to keep WikiLink syntax* some use-cases.
+
+My [[Use Case]] is that I want the [[transclusion]] to happen, but keep the wiki style link.
+
+Fancy made up word for including the other file inline.
+
+Like that.

--- a/tests/testdata/input/keep-wiki-links/Note.md
+++ b/tests/testdata/input/keep-wiki-links/Note.md
@@ -1,0 +1,7 @@
+Even though we're exporting from Obsidian, I [[Want to keep WikiLink syntax]] some use-cases.
+
+My [[Use Case]] is that I want the [[transclusion]] to happen, but keep the wiki style link.
+
+![[transclusion]]
+
+Like that.

--- a/tests/testdata/input/keep-wiki-links/transclusion.md
+++ b/tests/testdata/input/keep-wiki-links/transclusion.md
@@ -1,0 +1,2 @@
+
+Fancy made up word for including the other file inline.


### PR DESCRIPTION
I wanted to introduce the option to preserve the wikilink syntax when exporting from Obsidian. It's a requirement for my use-case.

My first attempt at rust-lang. More of a hack and slash than a learning experience. I'm hoping the original author (@zoni) could give some feedback on my bug.

There is a bug here that I'm stuck on. The resulting markdown prepends a backslash `\` to the link - as if it anticipates needing to escape it. Instead of `[[My Link to Another Concept]]` I'm getting `\[[My Link to Another Concept]]`.

For now I'm working around this in my workflow by using `sed -i 's/\\\[\[/\[\[/g' *.md` on the exported files.
